### PR TITLE
remove quotes to fix apt thinking muliple packages in quotes as single package

### DIFF
--- a/debian/bookworm/entrypoint.sh
+++ b/debian/bookworm/entrypoint.sh
@@ -16,4 +16,5 @@ echo "$APT_REPO_LINE" | tee /etc/apt/sources.list.d/regolith.list
 
 # Install target package
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y "$TARGET_PACKAGE"
+# shellcheck disable=SC2086
+DEBIAN_FRONTEND=noninteractive apt install -y $TARGET_PACKAGE

--- a/debian/bullseye/entrypoint.sh
+++ b/debian/bullseye/entrypoint.sh
@@ -16,4 +16,5 @@ echo "$APT_REPO_LINE" | tee /etc/apt/sources.list.d/regolith.list
 
 # Install target package
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y "$TARGET_PACKAGE"
+# shellcheck disable=SC2086
+DEBIAN_FRONTEND=noninteractive apt install -y $TARGET_PACKAGE

--- a/debian/testing/entrypoint.sh
+++ b/debian/testing/entrypoint.sh
@@ -16,4 +16,5 @@ echo "$APT_REPO_LINE" | tee /etc/apt/sources.list.d/regolith.list
 
 # Install target package
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y "$TARGET_PACKAGE"
+# shellcheck disable=SC2086
+DEBIAN_FRONTEND=noninteractive apt install -y $TARGET_PACKAGE

--- a/ubuntu/focal/entrypoint.sh
+++ b/ubuntu/focal/entrypoint.sh
@@ -16,4 +16,5 @@ echo "$APT_REPO_LINE" | tee /etc/apt/sources.list.d/regolith.list
 
 # Install target package
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y "$TARGET_PACKAGE"
+# shellcheck disable=SC2086
+DEBIAN_FRONTEND=noninteractive apt install -y $TARGET_PACKAGE

--- a/ubuntu/jammy/entrypoint.sh
+++ b/ubuntu/jammy/entrypoint.sh
@@ -16,4 +16,5 @@ echo "$APT_REPO_LINE" | tee /etc/apt/sources.list.d/regolith.list
 
 # Install target package
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y "$TARGET_PACKAGE"
+# shellcheck disable=SC2086
+DEBIAN_FRONTEND=noninteractive apt install -y $TARGET_PACKAGE

--- a/ubuntu/mantic/entrypoint.sh
+++ b/ubuntu/mantic/entrypoint.sh
@@ -16,4 +16,5 @@ echo "$APT_REPO_LINE" | tee /etc/apt/sources.list.d/regolith.list
 
 # Install target package
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y "$TARGET_PACKAGE"
+# shellcheck disable=SC2086
+DEBIAN_FRONTEND=noninteractive apt install -y $TARGET_PACKAGE

--- a/ubuntu/noble/entrypoint.sh
+++ b/ubuntu/noble/entrypoint.sh
@@ -16,4 +16,5 @@ echo "$APT_REPO_LINE" | tee /etc/apt/sources.list.d/regolith.list
 
 # Install target package
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y "$TARGET_PACKAGE"
+# shellcheck disable=SC2086
+DEBIAN_FRONTEND=noninteractive apt install -y $TARGET_PACKAGE


### PR DESCRIPTION
This fixes a CI validation issue I'm seeing in the package builder ([ex](https://github.com/regolith-linux/voulage/actions/runs/8994964409/job/24709239074)):

bad:

```
apt install -y 'regolith-desktop regolith-session-flashback'
```

good:

```
apt install -y regolith-desktop regolith-session-flashback
```


I missed this in PR, and should have refactored the code earlier to indicate that there may be more than a single package specified by `TARGET_PACKAGE`.  This PR just fixes the issue so I can proceed w/ the build.  I think removing the quotes is safe because debian packages (and other package managers I expect but also expect there are exceptions) do not allow whitespaces in the package names.
